### PR TITLE
Update nft_metadata function

### DIFF
--- a/src/nft-contract/index.ts
+++ b/src/nft-contract/index.ts
@@ -152,6 +152,6 @@ export class Contract extends NearContract {
     @view
     //Query for all the tokens for an owner
     nft_metadata() {
-        return internalNftMetadata(this);
+        return internalNftMetadata({ contract: this });
     }
 }


### PR DESCRIPTION
`internalNftMetadata` expects an object with a `contract` param.